### PR TITLE
[FEAT] 전시용 사용자 회원가입/로그인 구현

### DIFF
--- a/src/main/java/com/ssu/muzi/domain/member/controller/OauthController.java
+++ b/src/main/java/com/ssu/muzi/domain/member/controller/OauthController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import static com.ssu.muzi.global.result.code.MemberResultCode.CHECK_MEMBER_REGISTRATION;
+import static com.ssu.muzi.global.result.code.MemberResultCode.EXHIBITION_ADD;
 import static com.ssu.muzi.global.result.code.MemberResultCode.LOGIN;
 import static com.ssu.muzi.global.result.code.MemberResultCode.REFRESH_TOKEN;
 
@@ -49,4 +50,14 @@ public class OauthController {
     public ResultResponse<OauthResponse.CheckMemberRegistration> checkSignup(@Valid @RequestBody OauthRequest.LoginRequest request) {
         return ResultResponse.of(CHECK_MEMBER_REGISTRATION, oauthService.checkRegistration(request));
     }
+
+    // 전시용 회원가입
+    @PostMapping("/login/add-exhibition")
+    @Operation(summary = "전시용 회원가입 API", description = "전시용 회원가입을 진행하는 API 입니다.")
+    public ResultResponse<OauthResponse.ServerAccessTokenInfo> exhibitionAdd(@Valid @RequestBody OauthRequest.ExhibitionAddRequest request) {
+        return ResultResponse.of(EXHIBITION_ADD, oauthService.exhibitionAdd(request));
+    }
+
+
+
 }

--- a/src/main/java/com/ssu/muzi/domain/member/controller/OauthController.java
+++ b/src/main/java/com/ssu/muzi/domain/member/controller/OauthController.java
@@ -10,12 +10,18 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.ssu.muzi.global.result.code.MemberResultCode.CHECK_LOGIN_ID;
 import static com.ssu.muzi.global.result.code.MemberResultCode.CHECK_MEMBER_REGISTRATION;
 import static com.ssu.muzi.global.result.code.MemberResultCode.EXHIBITION_ADD;
 import static com.ssu.muzi.global.result.code.MemberResultCode.EXHIBITION_LOGIN;
@@ -64,5 +70,12 @@ public class OauthController {
     @Operation(summary = "전시용 로그인 API", description = "전시용 로그인 API입니다.")
     public ResultResponse<OauthResponse.ServerAccessTokenInfo> exhibitionLogin(@Valid @RequestBody OauthRequest.ExhibitionLoginRequest request) {
         return ResultResponse.of(EXHIBITION_LOGIN, oauthService.exhibitionLogin(request));
+    }
+
+    // 전시용 - 아이디 중복 검증
+    @GetMapping("/login/check-loginId")
+    @Operation(summary = "아이디 중복 검증 API", description = "입력된 loginId가 이미 존재하는지 확인하는 API입니다.")
+    public ResultResponse<OauthResponse.CheckLoginIdResponse> checkLoginId(@RequestParam @NotEmpty(message = "아이디는 필수로 입력해야 합니다.") String loginId) {
+        return ResultResponse.of(CHECK_LOGIN_ID, oauthService.checkLoginId(loginId));
     }
 }

--- a/src/main/java/com/ssu/muzi/domain/member/controller/OauthController.java
+++ b/src/main/java/com/ssu/muzi/domain/member/controller/OauthController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import static com.ssu.muzi.global.result.code.MemberResultCode.CHECK_MEMBER_REGISTRATION;
 import static com.ssu.muzi.global.result.code.MemberResultCode.EXHIBITION_ADD;
+import static com.ssu.muzi.global.result.code.MemberResultCode.EXHIBITION_LOGIN;
 import static com.ssu.muzi.global.result.code.MemberResultCode.LOGIN;
 import static com.ssu.muzi.global.result.code.MemberResultCode.REFRESH_TOKEN;
 
@@ -58,6 +59,10 @@ public class OauthController {
         return ResultResponse.of(EXHIBITION_ADD, oauthService.exhibitionAdd(request));
     }
 
-
-
+    // 전시용 로그인
+    @PostMapping("/login/login-exhibition")
+    @Operation(summary = "전시용 로그인 API", description = "전시용 로그인 API입니다.")
+    public ResultResponse<OauthResponse.ServerAccessTokenInfo> exhibitionLogin(@Valid @RequestBody OauthRequest.ExhibitionLoginRequest request) {
+        return ResultResponse.of(EXHIBITION_LOGIN, oauthService.exhibitionLogin(request));
+    }
 }

--- a/src/main/java/com/ssu/muzi/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/ssu/muzi/domain/member/converter/MemberConverter.java
@@ -1,9 +1,12 @@
 package com.ssu.muzi.domain.member.converter;
 
 import com.ssu.muzi.domain.member.dto.MemberResponse;
+import com.ssu.muzi.domain.member.dto.OauthRequest;
 import com.ssu.muzi.domain.member.dto.OauthResponse;
 import com.ssu.muzi.domain.member.entity.Member;
 import org.springframework.stereotype.Component;
+
+import java.util.UUID;
 
 @Component
 public class MemberConverter {
@@ -58,6 +61,22 @@ public class MemberConverter {
         return MemberResponse.MemberId
                 .builder()
                 .memberId(member.getId())
+                .build();
+    }
+
+    // 전시용 회원가입 시
+    public static Member toExhibitionMember(OauthRequest.ExhibitionAddRequest request) {
+
+        Long authId = Math.abs(UUID.randomUUID().getMostSignificantBits());
+
+        return Member.builder()
+                .loginId(request.getLoginId())
+                .loginPassword(request.getLoginPassword())
+                .name(request.getName())
+                .isFaceCaptured(false)
+                .onlyWifi(false)
+                .email(null)
+                .authId(authId)
                 .build();
     }
 

--- a/src/main/java/com/ssu/muzi/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/ssu/muzi/domain/member/converter/MemberConverter.java
@@ -80,4 +80,12 @@ public class MemberConverter {
                 .build();
     }
 
+    // 전시용 아이디 중복 확인
+    public static OauthResponse.CheckLoginIdResponse toCheckLoginIdResponse(boolean isAvailable) {
+        return OauthResponse.CheckLoginIdResponse
+                .builder()
+                .isAvailable(isAvailable)
+                .build();
+    }
+
 }

--- a/src/main/java/com/ssu/muzi/domain/member/dto/OauthRequest.java
+++ b/src/main/java/com/ssu/muzi/domain/member/dto/OauthRequest.java
@@ -40,4 +40,17 @@ public abstract class OauthRequest {
         @Size(min = 8, message = "비밀번호는 8자 이상 입력해야 합니다.")
         private String loginPassword;
     }
+
+    // 전시용 로그인
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ExhibitionLoginRequest {
+        @NotEmpty(message = "아이디 필수로 입력해야 합니다.")
+        private String loginId;
+        @NotEmpty(message = "비밀번호는 필수로 입력해야 합니다.")
+        @Size(min = 8, message = "비밀번호는 8자 이상 입력해야 합니다.")
+        private String loginPassword;
+    }
 }

--- a/src/main/java/com/ssu/muzi/domain/member/dto/OauthRequest.java
+++ b/src/main/java/com/ssu/muzi/domain/member/dto/OauthRequest.java
@@ -53,4 +53,5 @@ public abstract class OauthRequest {
         @Size(min = 8, message = "비밀번호는 8자 이상 입력해야 합니다.")
         private String loginPassword;
     }
+
 }

--- a/src/main/java/com/ssu/muzi/domain/member/dto/OauthRequest.java
+++ b/src/main/java/com/ssu/muzi/domain/member/dto/OauthRequest.java
@@ -1,6 +1,8 @@
 package com.ssu.muzi.domain.member.dto;
 
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,5 +23,21 @@ public abstract class OauthRequest {
     public static class LoginRequest {
         @NotNull(message = "카카오에서 제공한 회원 번호를 필수로 입력해야 합니다.")
         private Long authId;
+    }
+
+    // 전시용 회원가입
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ExhibitionAddRequest {
+        @NotEmpty(message = "닉네임은 필수로 입력해야 합니다.")
+        @Size(min = 2, max = 10, message = "닉네임은 최소 2자, 최대 5자까지 입력 가능합니다.")
+        private String name;
+        @NotEmpty(message = "아이디 필수로 입력해야 합니다.")
+        private String loginId;
+        @NotEmpty(message = "비밀번호는 필수로 입력해야 합니다.")
+        @Size(min = 8, message = "비밀번호는 8자 이상 입력해야 합니다.")
+        private String loginPassword;
     }
 }

--- a/src/main/java/com/ssu/muzi/domain/member/dto/OauthResponse.java
+++ b/src/main/java/com/ssu/muzi/domain/member/dto/OauthResponse.java
@@ -38,4 +38,13 @@ public abstract class  OauthResponse {
     public static class RefreshTokenResponse {
         private String accessToken;
     }
+
+    // id 중복 검증
+    @Getter
+    @Setter
+    @Builder
+    @AllArgsConstructor
+    public static class CheckLoginIdResponse {
+        private boolean isAvailable;
+    }
 }

--- a/src/main/java/com/ssu/muzi/domain/member/entity/Member.java
+++ b/src/main/java/com/ssu/muzi/domain/member/entity/Member.java
@@ -49,6 +49,10 @@ public class Member extends BaseTimeEntity {
     private String accessToken;      // Access Token
     @Column
     private String email;      // Access Token
+    @Column
+    private String loginId;     // 전시용
+    @Column
+    private String loginPassword;      // 전시용
 
     @OneToMany(mappedBy = "member")
     @Builder.Default

--- a/src/main/java/com/ssu/muzi/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/ssu/muzi/domain/member/repository/MemberRepository.java
@@ -13,4 +13,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByAuthId(Long authId);
     Optional<Member> findByRefreshToken(String refreshToken);
     Boolean existsByAuthId(Long authId);
+    Optional<Member> findByLoginId(String loginId);
 }

--- a/src/main/java/com/ssu/muzi/domain/member/service/OauthService.java
+++ b/src/main/java/com/ssu/muzi/domain/member/service/OauthService.java
@@ -13,4 +13,5 @@ public interface OauthService {
     String loginWithKakao(String accessToken, HttpServletResponse response);
     OauthResponse.RefreshTokenResponse tokenRefresh(HttpServletRequest request);
     OauthResponse.CheckMemberRegistration checkRegistration(OauthRequest.LoginRequest request);
+    OauthResponse.ServerAccessTokenInfo exhibitionAdd(OauthRequest.ExhibitionAddRequest request);
 }

--- a/src/main/java/com/ssu/muzi/domain/member/service/OauthService.java
+++ b/src/main/java/com/ssu/muzi/domain/member/service/OauthService.java
@@ -15,4 +15,5 @@ public interface OauthService {
     OauthResponse.CheckMemberRegistration checkRegistration(OauthRequest.LoginRequest request);
     OauthResponse.ServerAccessTokenInfo exhibitionAdd(OauthRequest.ExhibitionAddRequest request);
     OauthResponse.ServerAccessTokenInfo exhibitionLogin(OauthRequest.ExhibitionLoginRequest request);
+    OauthResponse.CheckLoginIdResponse checkLoginId(String loginId);
 }

--- a/src/main/java/com/ssu/muzi/domain/member/service/OauthService.java
+++ b/src/main/java/com/ssu/muzi/domain/member/service/OauthService.java
@@ -14,4 +14,5 @@ public interface OauthService {
     OauthResponse.RefreshTokenResponse tokenRefresh(HttpServletRequest request);
     OauthResponse.CheckMemberRegistration checkRegistration(OauthRequest.LoginRequest request);
     OauthResponse.ServerAccessTokenInfo exhibitionAdd(OauthRequest.ExhibitionAddRequest request);
+    OauthResponse.ServerAccessTokenInfo exhibitionLogin(OauthRequest.ExhibitionLoginRequest request);
 }

--- a/src/main/java/com/ssu/muzi/domain/member/service/OauthServiceImpl.java
+++ b/src/main/java/com/ssu/muzi/domain/member/service/OauthServiceImpl.java
@@ -20,6 +20,8 @@ import static com.ssu.muzi.global.error.code.JwtErrorCode.INVALID_REFRESH_TOKEN;
 import static com.ssu.muzi.global.error.code.JwtErrorCode.MEMBER_NOT_FOUND;
 import static com.ssu.muzi.global.error.code.OauthErrorCode.DUPLICATE_LOGIN_ID;
 import static com.ssu.muzi.global.error.code.OauthErrorCode.INVALID_PASSWORD;
+import static com.ssu.muzi.global.error.code.OauthErrorCode.MEMBER_LOGINID_NOT_FOUND;
+import static com.ssu.muzi.global.error.code.OauthErrorCode.NOT_CORRECT_PASSWORD;
 
 
 @Service
@@ -162,6 +164,27 @@ public class OauthServiceImpl implements OauthService {
         member.setAccessToken(accessToken);
         member.setRefreshToken(refreshToken);
 
+        return memberConverter.toServerAccessTokenInfo(accessToken, member);
+    }
+
+
+    @Override
+    // 전시용 로그인 시 처리하는 로직
+    public OauthResponse.ServerAccessTokenInfo exhibitionLogin(OauthRequest.ExhibitionLoginRequest request) {
+
+        // 아이디(로그인ID)로 회원 조회
+        Member member = memberRepository.findByLoginId(request.getLoginId())
+                .orElseThrow(() -> new BusinessException(MEMBER_LOGINID_NOT_FOUND));
+
+        // 비밀번호 검증
+        if (!member.getLoginPassword().equals(request.getLoginPassword())) {
+            throw new BusinessException(NOT_CORRECT_PASSWORD);
+        }
+
+        // 기존 액세스 토큰 확인
+        String accessToken = member.getAccessToken();
+
+        // 응답 DTO 생성
         return memberConverter.toServerAccessTokenInfo(accessToken, member);
     }
 

--- a/src/main/java/com/ssu/muzi/domain/member/service/OauthServiceImpl.java
+++ b/src/main/java/com/ssu/muzi/domain/member/service/OauthServiceImpl.java
@@ -188,4 +188,12 @@ public class OauthServiceImpl implements OauthService {
         return memberConverter.toServerAccessTokenInfo(accessToken, member);
     }
 
+    @Override
+    // 아이디 중복확인
+    public OauthResponse.CheckLoginIdResponse checkLoginId(String loginId) {
+        // loginId로 회원이 존재하는지 확인
+        boolean isAvailable = memberRepository.findByLoginId(loginId).isEmpty();
+        return MemberConverter.toCheckLoginIdResponse(isAvailable);
+    }
+
 }

--- a/src/main/java/com/ssu/muzi/domain/member/service/OauthServiceImpl.java
+++ b/src/main/java/com/ssu/muzi/domain/member/service/OauthServiceImpl.java
@@ -6,6 +6,7 @@ import com.ssu.muzi.domain.member.dto.OauthResponse;
 import com.ssu.muzi.domain.member.entity.Member;
 import com.ssu.muzi.domain.member.repository.MemberRepository;
 import com.ssu.muzi.global.error.BusinessException;
+import com.ssu.muzi.global.error.code.OauthErrorCode;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -17,6 +18,8 @@ import java.util.Arrays;
 
 import static com.ssu.muzi.global.error.code.JwtErrorCode.INVALID_REFRESH_TOKEN;
 import static com.ssu.muzi.global.error.code.JwtErrorCode.MEMBER_NOT_FOUND;
+import static com.ssu.muzi.global.error.code.OauthErrorCode.DUPLICATE_LOGIN_ID;
+import static com.ssu.muzi.global.error.code.OauthErrorCode.INVALID_PASSWORD;
 
 
 @Service
@@ -131,4 +134,35 @@ public class OauthServiceImpl implements OauthService {
         // 유효한 Refresh Token을 기반으로 새로운 Access Token을 생성하여 반환
         return jwtTokenService.createAccessToken(member.getAuthId().toString());
     }
+
+    @Override
+    // 전시용 회원가입 시 처리하는 로직
+    public OauthResponse.ServerAccessTokenInfo exhibitionAdd(OauthRequest.ExhibitionAddRequest request) {
+        // 아이디 중복 검증
+        String loginId = request.getLoginId();
+        if (memberRepository.findByLoginId(loginId).isPresent()) {
+            throw new BusinessException(DUPLICATE_LOGIN_ID);
+        }
+
+        // 비밀번호 길이 검증
+        if (request.getLoginPassword() == null || request.getLoginPassword().length() < 8) {
+            throw new BusinessException(INVALID_PASSWORD);
+        }
+
+        // 컨버터를 사용해 request에서 Member 엔티티 생성
+        Member member = MemberConverter.toExhibitionMember(request);
+        member.setMemberImageUrl("https://muzi-photo.s3.ap-northeast-2.amazonaws.com/memberImage/basicMemberImage.png");
+
+        // 회원 저장
+        member = memberRepository.save(member);
+
+        // 회원가입 성공 시, member의 loginId를 payload로 JWT 액세스 토큰 생성 + 리프레쉬 토큰
+        String accessToken = jwtTokenService.createAccessToken(member.getAuthId().toString());
+        String refreshToken = jwtTokenService.createRefreshToken();
+        member.setAccessToken(accessToken);
+        member.setRefreshToken(refreshToken);
+
+        return memberConverter.toServerAccessTokenInfo(accessToken, member);
+    }
+
 }

--- a/src/main/java/com/ssu/muzi/global/error/code/OauthErrorCode.java
+++ b/src/main/java/com/ssu/muzi/global/error/code/OauthErrorCode.java
@@ -1,0 +1,17 @@
+package com.ssu.muzi.global.error.code;
+
+import com.ssu.muzi.global.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OauthErrorCode implements ErrorCode {
+    DUPLICATE_LOGIN_ID(404, "EO000", "중복된 아이디입니다."),
+    INVALID_PASSWORD(404, "EM001", "비밀번호가 비어 있거나 8자 이하인지 확인해주세요."),
+    ;
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/ssu/muzi/global/error/code/OauthErrorCode.java
+++ b/src/main/java/com/ssu/muzi/global/error/code/OauthErrorCode.java
@@ -9,6 +9,9 @@ import lombok.RequiredArgsConstructor;
 public enum OauthErrorCode implements ErrorCode {
     DUPLICATE_LOGIN_ID(404, "EO000", "중복된 아이디입니다."),
     INVALID_PASSWORD(404, "EM001", "비밀번호가 비어 있거나 8자 이하인지 확인해주세요."),
+    MEMBER_LOGINID_NOT_FOUND(404, "EM002", "해당 id가 존재하지 않습니다. (전시용 로그인)"),
+    NOT_CORRECT_PASSWORD(404, "EM003", "해당 패스워드는 유효하지 않습니다. (전시용 로그인)"),
+
     ;
 
     private final int status;

--- a/src/main/java/com/ssu/muzi/global/result/code/MemberResultCode.java
+++ b/src/main/java/com/ssu/muzi/global/result/code/MemberResultCode.java
@@ -18,6 +18,7 @@ public enum MemberResultCode implements ResultCode {
     DELETE_MEMBER(200, "SM008", "성공적으로 회원 탈퇴했습니다."),
     EXHIBITION_LOGIN(200, "SM009", "성공적으로 전시용 로그인했습니다."),
     EXHIBITION_ADD(200, "SM010", "성공적으로 전시용 회원가입했습니다."),
+    CHECK_LOGIN_ID(200, "SM011", "성공적으로 아이디 중복 여부를 체크하였습니다."),
     ;
     private final int status;
     private final String code;

--- a/src/main/java/com/ssu/muzi/global/result/code/MemberResultCode.java
+++ b/src/main/java/com/ssu/muzi/global/result/code/MemberResultCode.java
@@ -16,6 +16,8 @@ public enum MemberResultCode implements ResultCode {
     SET_IMAGE(200, "SM006", "성공적으로 프로필 사진을 수정하였습니다."),
     SET_WIFI(200, "SM007", "성공적으로 와이파이 다운로드 여부를 변경했습니다."),
     DELETE_MEMBER(200, "SM008", "성공적으로 회원 탈퇴했습니다."),
+    EXHIBITION_LOGIN(200, "SM009", "성공적으로 전시용 로그인했습니다."),
+    EXHIBITION_ADD(200, "SM010", "성공적으로 전시용 회원가입했습니다."),
     ;
     private final int status;
     private final String code;


### PR DESCRIPTION
저희 서비스에서는 ios 사용자를 고려하고자, 전시용 기기로 체험할 수 있게 하기 위해 전시용 '일반 로그인'을 만들게 되었습니다.
이때 소셜 로그인으로 진행하면 2차인증 등 기타 요소들이 전시 흐름에 방해가 되기 때문에,
또한 체험을 위해 전시에서만 한시적으로 쓰일 용도이기 때문에,
복잡한 보안 요소를 제거하고 (ex. 이메일 인증) 직접 id/비밀번호를 만들어 쉽게 로그인할 수 있는 API를 구성하였습니다.

회원가입 절차를 거치면, 서버에서 자체 액세스 토큰을 생성해 서버에 저장합니다. 세부 정책은 카카오 로그인과 같습니다.
전시용 회원가입 시, UUID를 통해 고유 authId를 자체 생성합니다.
이 authId를 payload로 사용해 JWT 토큰을 생성합니다.
이후 해당 액세스 토큰을 통해 사용자를 식별합니다.
회원가입 API
id, 비밀번호, 사용자 이름을 받아 회원가입합니다.
id는 중복될 수 없습니다.
비밀번호는 8자 이상이어야 합니다.
아이디 중복 검증 및 나머지 칸 입력이 모두 되어야 회원가입할 수 있습니다. (프론트엔드에서 확인 후 활성화)
아이디 중복 검증 API
회원가입 중 입력한 id를 request로 보내어, 이미 서버에 존재하는지 검증합니다.
로그인 시 클라이언트에서 이 API를 호출해야 하고, 이 API의 결과가 '중복 안됨' 이어야 회원가입이 가능합니다.
로그인 API
id, 비밀번호를 받아 로그인합니다.
id가 DB에 없을 시, 비밀번호가 유효하지 않을 시 -> 따로 에러메시지를 보여줍니다.