### PR TITLE
[REFACTOR] https로 변경

### DIFF
--- a/.github/workflows/muzi-cicd.yml
+++ b/.github/workflows/muzi-cicd.yml
@@ -36,6 +36,10 @@ jobs:
     - run: echo "${{ secrets.APPLICATION }}" > ./src/main/resources/application.yml
     - run: cat ./src/main/resources/application.yml
 
+# keystore.p12 파일 설정
+    - run: echo "${{ secrets.KEYSTORE_P12 }}" | base64 --decode > ./src/main/resources/keystore.p12
+    - run: ls -la ./src/main/resources/keystore.p12 # 파일이 생성되었는지 확인
+
 # (3) gradlew 권한 추가
     - name: Run chmod to make gradlew executable
       run: chmod +x ./gradlew

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ out/
 ### VS Code ###
 .vscode/
 
-application.yml
 firebase_key.json
 *.log
+
+## 사용자 지정
+application.yml
+keystore.p12

--- a/src/main/java/com/ssu/muzi/domain/photo/service/PhotoServiceImpl.java
+++ b/src/main/java/com/ssu/muzi/domain/photo/service/PhotoServiceImpl.java
@@ -154,6 +154,7 @@ public class PhotoServiceImpl implements PhotoService {
                 .uploaderProfileId(uploaderProfile.getId())
                 .uploadPhotoList(list)
                 .build();
+
     }
 
 


### PR DESCRIPTION
- http에서 https로 전환할 예정입니다.
- 무료 SSL 인증서를 발급해주는 Let's Encrypt 라는 CA 기관에서 인증서를 받기 위해,
Let's Encrypt의 ACME 프로토콜을 이용해 인증서를 자동으로 발급받고 갱신하는 클라이언트인 certBot을 사용하였습니다.
(인증서 발급/갱신 자동화)
- 인증서 인증 방법은 standalone 방식을 사용하였습니다.